### PR TITLE
fix: correct cost display by fixing printf quoting in bash generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.5] - 2025-08-27
+
+### Fixed
+- 🐛 **Cost Display Fix** - Fixed incorrect cost values (e.g., $48.00) caused by improper quoting in printf statements
+  - Removed unnecessary escaped quotes around `$cost_usd` in bash generator
+  - Cost values now display correctly with proper decimal formatting
+
+## [1.2.4] - 2025-08-26
 
 ### Added
 - 🆕 **Installation Location Choice** - Choose between global (`~/.claude`) or project-level (`./.claude`) installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chongdashu/cc-statusline",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Interactive CLI tool for generating custom Claude Code statuslines",
   "type": "module",
   "main": "dist/index.js",

--- a/src/generators/bash-generator.ts
+++ b/src/generators/bash-generator.ts
@@ -196,11 +196,11 @@ line3=""${usageConfig.showCost ? `
 if [ -n "$cost_usd" ] && [[ "$cost_usd" =~ ^[0-9.]+$ ]]; then${usageConfig.showBurnRate ? `
   if [ -n "$cost_per_hour" ] && [[ "$cost_per_hour" =~ ^[0-9.]+$ ]]; then
     cost_per_hour_formatted=$(printf '%.2f' "$cost_per_hour")
-    line3="💰 $(cost_color)\\$$(printf '%.2f' \\"$cost_usd\\")$(rst) ($(burn_color)\\$\${cost_per_hour_formatted}/h$(rst))"
+    line3="💰 $(cost_color)\\$$(printf '%.2f' "$cost_usd")$(rst) ($(burn_color)\\$\${cost_per_hour_formatted}/h$(rst))"
   else
-    line3="💰 $(cost_color)\\$$(printf '%.2f' \\"$cost_usd\\")$(rst)"
+    line3="💰 $(cost_color)\\$$(printf '%.2f' "$cost_usd")$(rst)"
   fi` : `
-  line3="💰 $(cost_color)\\$$(printf '%.2f' \\"$cost_usd\\")$(rst)"`}
+  line3="💰 $(cost_color)\\$$(printf '%.2f' "$cost_usd")$(rst)"`}
 fi` : ''}${usageConfig.showTokens ? `
 if [ -n "$tot_tokens" ] && [[ "$tot_tokens" =~ ^[0-9]+$ ]]; then${usageConfig.showBurnRate ? `
   if [ -n "$tpm" ] && [[ "$tpm" =~ ^[0-9.]+$ ]]; then


### PR DESCRIPTION
- Fixed incorrect cost values (e.g., $48.00) caused by improper escaped quotes
- Removed unnecessary backslash escaping around $cost_usd in printf statements
- Cost values now display correctly with proper decimal formatting

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)